### PR TITLE
Wrap UG_FONT struct byte array access with macro in case an accessor function is needed

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,5 @@
+CC=gcc
+CFLAGS=-g -std=c99 `sdl2-config --libs --cflags`
+
+all:
+	${CC} ${CFLAGS} -o ugui_sim sdl.c ../ugui.c -I../ phone.c

--- a/examples/phone.c
+++ b/examples/phone.c
@@ -1,0 +1,71 @@
+#include "ugui.h"
+#define D_FONT FONT_10X16
+#define MAX_OBJECTS 100
+
+
+UG_WINDOW window1;
+UG_TEXTBOX textbox1;
+UG_BUTTON numpad[12];
+static char *glyphs[12] = {"1", "2", "3",
+													 "4", "5", "6",
+													 "7", "8", "9",
+													 "X", "0", "C"};
+UG_OBJECT objs[MAX_OBJECTS];
+static char number[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+int np;
+
+void window1_callback(UG_MESSAGE *msg){
+	if (msg->type == MSG_TYPE_OBJECT){
+		if(msg->id == OBJ_TYPE_BUTTON){
+			if (msg->event == OBJ_EVENT_PRESSED || msg->event == OBJ_EVENT_CLICKED){
+				if ((msg->sub_id >= 0 && msg->sub_id <= 8) || msg->sub_id == 10){
+					if (np < sizeof(number)-1){
+						number[np++] = glyphs[msg->sub_id][0];
+						UG_TextboxSetText(&window1, TXB_ID_0, number);
+					}
+				}
+				else {
+					if (msg->sub_id == 11)
+						UG_TextboxSetText(&window1, TXB_ID_0, "Calling..");
+					else if (msg->sub_id == 9){
+						number[--np] = 0x00;
+						UG_TextboxSetText(&window1, TXB_ID_0, number);
+					}
+				}
+			}
+		}
+	}
+}
+
+void ui_setup(){
+
+	UG_FontSelect(&D_FONT);
+	UG_WindowCreate(&window1, objs, MAX_OBJECTS, window1_callback);
+
+	UG_WindowSetTitleText(&window1, "Caller UI");
+	UG_WindowSetTitleTextFont(&window1, &D_FONT);
+
+	UG_TextboxCreate(&window1, &textbox1, TXB_ID_0, 10, 10, 230, 34);
+	UG_TextboxSetFont(&window1, TXB_ID_0, &D_FONT);
+	UG_TextboxSetText(&window1, TXB_ID_0, "enter number");
+	UG_TextboxSetForeColor(&window1, TXB_ID_0, C_BLACK);
+
+	for (int y = 0; y < 4; y++){
+		for (int x = 0; x < 3; x++){
+			int i = y*3 + x;
+#define BTN_SIZE 55
+			UG_ButtonCreate(&window1, &numpad[i], BTN_ID_0+i, 40+((x)*BTN_SIZE), 20+30+((y)*BTN_SIZE), 85+((x)*BTN_SIZE), 50+30+15+((y)*BTN_SIZE)); 
+			UG_ButtonSetStyle(&window1, BTN_ID_0+i, BTN_STYLE_2D);
+			UG_ButtonSetFont(&window1, BTN_ID_0+i, &D_FONT);
+			UG_ButtonSetText(&window1, BTN_ID_0+i, glyphs[i]);
+			UG_ButtonSetBackColor(&window1, BTN_ID_0+i, C_BLACK);
+			UG_ButtonSetForeColor(&window1, BTN_ID_0+i, C_WHITE);
+		}
+	}
+
+	UG_WindowShow(&window1);
+}
+
+void ui_loop(){
+
+}

--- a/examples/sdl.c
+++ b/examples/sdl.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <SDL2/SDL.h>
+#include "ugui.h"
+
+#define DISPLAY_COLS 240
+#define DISPLAY_ROWS 340
+
+uint32_t display[DISPLAY_COLS*DISPLAY_ROWS];
+
+extern void ui_setup(void);
+extern void ui_loop(void);
+
+void PixelFunc(UG_S16 x, UG_S16 y, UG_COLOR c){
+	display[(y*DISPLAY_COLS)+x] = (c<<8);
+}
+
+int main(int argc, char **argv){
+
+	UG_GUI gui;
+
+	UG_Init(&gui, PixelFunc, DISPLAY_COLS, DISPLAY_ROWS);
+	UG_SelectGUI(&gui);
+
+	if (SDL_Init(SDL_INIT_EVERYTHING) != 0){
+		fprintf(stderr, "Unable to initialize SDL: %s\n", SDL_GetError());
+		return 1;
+	}
+
+	SDL_Window   * window = SDL_CreateWindow("uGUI simulator", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, DISPLAY_COLS, DISPLAY_ROWS, 0);
+	SDL_Renderer * render = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+	SDL_Texture  * texture = SDL_CreateTexture(render, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STATIC, DISPLAY_COLS, DISPLAY_ROWS);
+
+	memset(display, 0x00, sizeof(uint32_t)*DISPLAY_COLS*DISPLAY_ROWS);
+
+	ui_setup();
+
+	SDL_UpdateTexture(texture, NULL, display, DISPLAY_COLS*sizeof(uint32_t));
+	SDL_RenderCopy(render, texture, NULL, NULL);
+	SDL_RenderPresent(render);
+
+	while (1){
+
+		SDL_Event event;
+
+		for (; SDL_PollEvent(&event); ){
+			switch(event.type){
+				case SDL_MOUSEBUTTONDOWN:
+					UG_TouchUpdate(event.button.x, event.button.y, TOUCH_STATE_PRESSED);
+					break;
+				case SDL_MOUSEBUTTONUP:
+					UG_TouchUpdate(-1, -1, TOUCH_STATE_RELEASED);
+					break;
+				case SDL_QUIT:
+					return 0;
+				default:
+					break;
+			}
+		}
+
+		ui_loop();
+		UG_Update();
+		SDL_UpdateTexture(texture, NULL, display, DISPLAY_COLS*sizeof(uint32_t));
+		SDL_RenderCopy(render, texture, NULL, NULL);
+		SDL_RenderPresent(render);
+		SDL_Delay(40);
+	}
+}

--- a/ugui.c
+++ b/ugui.c
@@ -5298,7 +5298,7 @@ void _UG_PutChar( char chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc, const 
 			 c=actual_char_width;
 			 for( i=0;i<bn;i++ )
 			 {
-				b = font->p[index++];
+				b = FONT_DATA_ACCESS(font->p[index++]);
 				for( k=0;(k<8) && c;k++ )
 				{
 				   if( b & 0x01 )
@@ -5322,7 +5322,7 @@ void _UG_PutChar( char chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc, const 
 		   {
 			  for( i=0;i<actual_char_width;i++ )
 			  {
-				 b = font->p[index++];
+				 b = FONT_DATA_ACCESS(font->p[index++]);
 				 color = (((fc & 0xFF) * b + (bc & 0xFF) * (256 - b)) >> 8) & 0xFF |//Blue component
 				         (((fc & 0xFF00) * b + (bc & 0xFF00) * (256 - b)) >> 8)  & 0xFF00|//Green component
 				         (((fc & 0xFF0000) * b + (bc & 0xFF0000) * (256 - b)) >> 8) & 0xFF0000; //Red component
@@ -5344,7 +5344,7 @@ void _UG_PutChar( char chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc, const 
            c=actual_char_width;
            for( i=0;i<bn;i++ )
            {
-             b = font->p[index++];
+             b = FONT_DATA_ACCESS(font->p[index++]);
              for( k=0;(k<8) && c;k++ )
              {
                if( b & 0x01 )
@@ -5371,7 +5371,7 @@ void _UG_PutChar( char chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc, const 
             xo = x;
             for( i=0;i<actual_char_width;i++ )
             {
-               b = font->p[index++];
+               b = FONT_DATA_ACCESS(font->p[index++]);
                color = (((fc & 0xFF) * b + (bc & 0xFF) * (256 - b)) >> 8) & 0xFF |//Blue component
                        (((fc & 0xFF00) * b + (bc & 0xFF00) * (256 - b)) >> 8)  & 0xFF00|//Green component
                        (((fc & 0xFF0000) * b + (bc & 0xFF0000) * (256 - b)) >> 8) & 0xFF0000; //Red component

--- a/ugui_config.h
+++ b/ugui_config.h
@@ -34,6 +34,9 @@
 /* Specify platform-dependent integer types here */
 
 #define __UG_FONT_DATA const
+/* Override if you store font data not in RAM/SRAM
+ * for example for pgm_read_byte w/ PROGMEM on AVR */
+#define FONT_DATA_ACCESS(x) (x)
 typedef uint8_t      UG_U8;
 typedef int8_t       UG_S8;
 typedef uint16_t     UG_U16;


### PR DESCRIPTION
Just a simple macro to allow for an alternative font data storage location that doesn't kill SRAM/RAM space. In AVR if you don't use the PROGMEM attribute in __UG_FONT_DATA, the font data takes up more than the available SRAM on the chip, but using the PROGMEM attribute requires accessing the font bytes with `pgm_read_byte(&(font->p[index++]))`. The macro allows configuring this accessor from ugui_config.h
